### PR TITLE
bump awscli version to 1.14.61

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.7
 
 ARG AWS_DEFAULT_REGION=us-east-1
-ARG AWSCLI_VER=1.14.2
+ARG AWSCLI_VER=1.14.61
 
 RUN apk add --no-cache --upgrade python3 bash && \
     pip3 install awscli==${AWSCLI_VER} --upgrade --no-cache-dir && \


### PR DESCRIPTION
To pickup working aws ec2 create-snapshot --tag-specifications.