### PR TITLE
DM-35401: Update awscli version to 1.25.21.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:3
 
 ARG AWS_DEFAULT_REGION=us-east-1
+# This default version is always overridden in the Jenkins context by a value
+# from configuration in jenkins-dm-jobs
 ARG AWSCLI_VER=1.25.21
 
 RUN apk add --no-cache --upgrade python3 py3-pip bash && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3
 
 ARG AWS_DEFAULT_REGION=us-east-1
-ARG AWSCLI_VER=1.14.61
+ARG AWSCLI_VER=1.25.21
 
 RUN apk add --no-cache --upgrade python3 py3-pip bash && \
     pip3 install awscli==${AWSCLI_VER} --upgrade --no-cache-dir && \


### PR DESCRIPTION
This will hopefully resolve a Python 3.10 incompatibility in botocore.